### PR TITLE
Allow passing in of variables to octopus deployment

### DIFF
--- a/src/main/java/com/octopusdeploy/api/DeploymentProcess.java
+++ b/src/main/java/com/octopusdeploy/api/DeploymentProcess.java
@@ -26,4 +26,9 @@ public class DeploymentProcess {
         this.projectId = projectId;
         this.steps = steps;
     }
+
+    @Override
+    public String toString() {
+        return "DeploymentProcess [id=" + id + ", projectId=" + projectId + ", steps=" + steps + "]";
+    }
 }

--- a/src/main/java/com/octopusdeploy/api/DeploymentProcessStep.java
+++ b/src/main/java/com/octopusdeploy/api/DeploymentProcessStep.java
@@ -26,4 +26,9 @@ public class DeploymentProcessStep {
         this.name = name;
         this.actions = actions;
     }
+
+    @Override
+    public String toString() {
+        return "DeploymentProcessStep [id=" + id + ", name=" + name + ", actions=" + actions + "]";
+    }
 }

--- a/src/main/java/com/octopusdeploy/api/DeploymentProcessStepAction.java
+++ b/src/main/java/com/octopusdeploy/api/DeploymentProcessStepAction.java
@@ -33,4 +33,9 @@ public class DeploymentProcessStepAction {
         this.actionType = actionType;
         this.properties = properties;
     }
+
+    @Override
+    public String toString() {
+        return "DeploymentProcessStepAction [id=" + id + ", name=" + name + ", actionType=" + actionType + ", properties=" + properties + "]";
+    }
 }

--- a/src/main/java/com/octopusdeploy/api/DeploymentProcessTemplate.java
+++ b/src/main/java/com/octopusdeploy/api/DeploymentProcessTemplate.java
@@ -26,4 +26,9 @@ public class DeploymentProcessTemplate {
         this.projectId = projectId;
         this.packages = packages;
     }
+
+    @Override
+    public String toString() {
+        return "DeploymentProcessTemplate [id=" + id + ", projectId=" + projectId + ", packages=" + packages + "]";
+    }
 }

--- a/src/main/java/com/octopusdeploy/api/Environment.java
+++ b/src/main/java/com/octopusdeploy/api/Environment.java
@@ -27,4 +27,9 @@ public class Environment {
         this.name = name;
         this.description = description;
     }
+
+    @Override
+    public String toString() {
+        return "Environment [name=" + name + ", id=" + id + ", description=" + description + "]";
+    }
 }

--- a/src/main/java/com/octopusdeploy/api/ErrorParser.java
+++ b/src/main/java/com/octopusdeploy/api/ErrorParser.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 /**
  * Parses errors from Octopus html/javascript responses
  * @author jlabroad
@@ -81,7 +83,8 @@ public class ErrorParser {
             String errors = m.group("fullDetailString");
             m = errDetailsInsidePattern.matcher(errors);
             while (m.find() && m.groupCount() > 0) {
-                errorList.add("\t" + m.group("singleError"));
+                String singleError = StringEscapeUtils.unescapeJava(m.group("singleError"));
+                errorList.add("\t" + singleError);
             }
         }    
         return errorList;

--- a/src/main/java/com/octopusdeploy/api/OctopusApi.java
+++ b/src/main/java/com/octopusdeploy/api/OctopusApi.java
@@ -199,6 +199,36 @@ public class OctopusApi {
     }
 
     /**
+     * Get the variables for a combination of release and environment, return null otherwise.
+     * @param releaseId The id of the Release.
+     * @param environmentId The id of the Environment.
+     * @return A set of all variables for a given Release and Environment combination.
+     * @throws IllegalArgumentException
+     * @throws IOException 
+     */
+    public Set<Variable> getVariablesByReleaseAndEnvironment(String releaseId, String environmentId) throws IllegalArgumentException, IOException {
+        Set<Variable> variables = new HashSet<Variable>();
+        
+        AuthenticatedWebClient.WebResponse response = webClient.get("api/releases/" + releaseId + "/deployments/preview/" + environmentId);
+        if (response.isErrorCode()) {
+            throw new IOException(String.format("Code %s - %n%s", response.getCode(), response.getContent()));
+        }
+        JSONObject json = (JSONObject)JSONSerializer.toJSON(response.getContent());
+        JSONObject form = json.getJSONObject("Form");
+        if (form != null){
+            for (Object obj : form.getJSONArray("Elements")) {
+                JSONObject jsonObj = (JSONObject)obj;
+                String id = jsonObj.getString("Name");
+                String name = jsonObj.getJSONObject("Control").getString("Name");
+                String description = jsonObj.getJSONObject("Control").getString("Description");
+                variables.add(new Variable(id, name, "", description));
+            }
+        }
+      
+        return variables;
+    }
+
+    /**
      * Get all releases for a given project from the Octopus server;
      * @param projectId
      * @return A set of all releases for a given project

--- a/src/main/java/com/octopusdeploy/api/OctopusApi.java
+++ b/src/main/java/com/octopusdeploy/api/OctopusApi.java
@@ -80,7 +80,34 @@ public class OctopusApi {
      * @throws IOException 
      */
     public String executeDeployment(String releaseId, String environmentId) throws IOException {
-        String json = String.format("{EnvironmentId:\"%s\",ReleaseId:\"%s\"}", environmentId, releaseId);
+          return  executeDeployment( releaseId,  environmentId, null);
+    }
+
+    /**
+     * Deploys a given release to provided environment.
+     * @param releaseId Release Id from Octopus to deploy.
+     * @param environmentId Environment Id from Octopus to deploy to.
+     * @param variables Variables used during deployment.
+     * @return the content of the web response.
+     * @throws IOException 
+     */
+    public String executeDeployment(String releaseId, String environmentId, Set<Variable> variables) throws IOException {
+
+        StringBuilder jsonBuilder = new StringBuilder();
+        jsonBuilder.append(String.format("{EnvironmentId:\"%s\",ReleaseId:\"%s\"", environmentId, releaseId));
+
+        if (variables != null && !variables.isEmpty()) {
+            jsonBuilder.append(",FormValues:{");
+            Set<String> variablesStrings = new HashSet<String>();
+            for (Variable v : variables) {
+                variablesStrings.add(String.format("\"%s\":\"%s\"", v.getId(), v.getValue()));
+            }
+            jsonBuilder.append(StringUtils.join(variablesStrings, ","));
+            jsonBuilder.append("}");
+        }
+        jsonBuilder.append("}");
+        String json = jsonBuilder.toString();
+
         byte[] data = json.getBytes(Charset.forName(UTF8));
         AuthenticatedWebClient.WebResponse response = webClient.post("api/deployments", data);
         if (response.isErrorCode()) {
@@ -206,7 +233,7 @@ public class OctopusApi {
      * @throws IllegalArgumentException
      * @throws IOException 
      */
-    public Set<Variable> getVariablesByReleaseAndEnvironment(String releaseId, String environmentId) throws IllegalArgumentException, IOException {
+    public Set<Variable> getVariablesByReleaseAndEnvironment(String releaseId, String environmentId, Properties entryProperties) throws IllegalArgumentException, IOException {
         Set<Variable> variables = new HashSet<Variable>();
         
         AuthenticatedWebClient.WebResponse response = webClient.get("api/releases/" + releaseId + "/deployments/preview/" + environmentId);
@@ -216,12 +243,19 @@ public class OctopusApi {
         JSONObject json = (JSONObject)JSONSerializer.toJSON(response.getContent());
         JSONObject form = json.getJSONObject("Form");
         if (form != null){
+            JSONObject formValues = form.getJSONObject("Values");
             for (Object obj : form.getJSONArray("Elements")) {
-                JSONObject jsonObj = (JSONObject)obj;
+                JSONObject jsonObj = (JSONObject) obj;
                 String id = jsonObj.getString("Name");
                 String name = jsonObj.getJSONObject("Control").getString("Name");
+                String value = formValues.getString(id);
+
+                String entryValue = entryProperties.getProperty(name);
+                if (StringUtils.isNotEmpty(entryValue)) {
+                    value = entryValue;
+                }
                 String description = jsonObj.getJSONObject("Control").getString("Description");
-                variables.add(new Variable(id, name, "", description));
+                variables.add(new Variable(id, name, value, description));
             }
         }
       

--- a/src/main/java/com/octopusdeploy/api/Project.java
+++ b/src/main/java/com/octopusdeploy/api/Project.java
@@ -18,5 +18,9 @@ public class Project {
         this.id = id;
         this.name = name;
     }
-            
+
+    @Override
+    public String toString() {
+        return "Project [name=" + name + ", id=" + id + "]";
+    }
 }

--- a/src/main/java/com/octopusdeploy/api/Release.java
+++ b/src/main/java/com/octopusdeploy/api/Release.java
@@ -30,4 +30,10 @@ public class Release {
         this.releaseNotes = releaseNotes;
         this.version = version;
     }
+
+    @Override
+    public String toString() {
+        return "Release [id=" + id + ", projectId=" + projectId + ", releaseNotes=" + releaseNotes + ", version=" + version + "]";
+    }
+
 }

--- a/src/main/java/com/octopusdeploy/api/SelectedPackage.java
+++ b/src/main/java/com/octopusdeploy/api/SelectedPackage.java
@@ -18,4 +18,10 @@ public class SelectedPackage {
         this.stepName = stepName;
         this.version = version;
     }
+
+    @Override
+    public String toString() {
+        return "SelectedPackage [stepName=" + stepName + ", version=" + version + "]";
+    }
+
 }

--- a/src/main/java/com/octopusdeploy/api/Task.java
+++ b/src/main/java/com/octopusdeploy/api/Task.java
@@ -38,4 +38,10 @@ public class Task {
         this.state = state;
         this.isCompleted = isCompleted;
     }
+
+    @Override
+    public String toString() {
+        return "Task [id=" + id + ", name=" + name + ", description=" + description + ", state=" + state + ", isCompleted=" + isCompleted + "]";
+    }
+    
 }

--- a/src/main/java/com/octopusdeploy/api/Variable.java
+++ b/src/main/java/com/octopusdeploy/api/Variable.java
@@ -31,4 +31,10 @@ public class Variable {
         this.value = value;
         this.description = description;
     }
+
+    @Override
+    public String toString() {
+        return "Variable [name=" + name + ", value=" + value + ", id=" + id + ", description=" + description + "]";
+    }
+
 }

--- a/src/main/java/com/octopusdeploy/api/Variable.java
+++ b/src/main/java/com/octopusdeploy/api/Variable.java
@@ -1,0 +1,34 @@
+package com.octopusdeploy.api;
+
+/**
+ * Represents a variable that will be passed to a deployment.
+ */
+public class Variable {
+    private final String name;
+    public String getName() {
+        return name;
+    }
+    
+    private final String value;
+    public String getValue() {
+        return value;
+    }
+    
+    private final String id;
+    public String getId() {
+        return id;
+    }
+    
+    private final String description;
+    public String getDescription() {
+        return description;
+    }
+    
+    public Variable(String id, String name, String value, String description)
+    {
+        this.id = id;
+        this.name = name;
+        this.value = value;
+        this.description = description;
+    }
+}

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder.java
@@ -11,7 +11,6 @@ import hudson.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.sf.json.*;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.*;
 
 /**

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder.java
@@ -146,6 +146,18 @@ public class OctopusDeployDeploymentRecorder extends Recorder implements Seriali
             log.fatal(String.format("Unable to find release version %s for project %s", releaseVersion, project));
             return false;
         }
+        
+        // TODO: Can we tell if we need to call? For now I will always try and get variable and use if I find them
+        Set<com.octopusdeploy.api.Variable> variables = null;
+        try {
+            String releaseId = releaseToDeploy.getId();
+            String environmentId = env.getId();
+            variables = api.getVariablesByReleaseAndEnvironment(releaseId, environmentId);
+        } catch (Exception ex) {
+            log.fatal(String.format("Retrieving variables for release '%s' to environment '%s' failed with message '%s'",
+                    releaseToDeploy.getId(), env.getName(), ex.getMessage()));
+            success = false;
+        }
         try {
             String results = api.executeDeployment(releaseToDeploy.getId(), env.getId());
             if (isTaskJson(results)) {

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
@@ -260,7 +260,7 @@ public class OctopusDeployReleaseRecorder extends Recorder implements Serializab
         }
 
         if (success && deployThisRelease) {
-          OctopusDeployDeploymentRecorder deployment = new OctopusDeployDeploymentRecorder(project, releaseVersion, environment, waitForDeployment);
+          OctopusDeployDeploymentRecorder deployment = new OctopusDeployDeploymentRecorder(project, releaseVersion, environment, "", waitForDeployment);
           success = deployment.perform(build, launcher, listener);
         }
 

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/config.jelly
@@ -8,6 +8,9 @@
   <f:entry title="Environment" field="environment">
     <f:combobox />
   </f:entry>
+  <f:entry title="Variables" field="variables">
+    <f:textarea />
+  </f:entry>
   <f:entry title="Wait for deployment to complete" field="waitForDeployment">
     <f:checkbox  value="false" />
   </f:entry>

--- a/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/help-variables.html
+++ b/src/main/resources/hudson/plugins/octopusdeploy/OctopusDeployDeploymentRecorder/help-variables.html
@@ -1,0 +1,5 @@
+<div>
+    List of variable to pass to the Depoyment process
+  <br />
+  <em>Use Java properties notation</em>
+</div>


### PR DESCRIPTION
https://github.com/vistaprint/octopus-jenkins-plugin/issues/5
* Added a text area to put the properties to pass along
* Added Variable API object
* Added logic to merge interface values and default values from Octopus 
Used .../OctopusDeploy-Api/wiki/DeploymentPreviews to get current set of variables to pass to deployment, and .../OctopusDeploy-Api/wiki/Deployments to figure out the need to pass FormValues with the variables defined as "[guid]": "value"

This is probably the begining since for now I am assuming all variable are strings.