### PR TITLE
Updates to package referencing within steps

### DIFF
--- a/src/main/java/com/octopusdeploy/api/DeploymentsApi.java
+++ b/src/main/java/com/octopusdeploy/api/DeploymentsApi.java
@@ -137,8 +137,9 @@ public class DeploymentsApi {
             JSONObject pkgJsonObj = (JSONObject) pkgObj;
             String name = pkgJsonObj.getString("StepName");
             String packageId = pkgJsonObj.getString("PackageId");
+            String packageReferenceName = pkgJsonObj.getString("PackageReferenceName");
             String version = pkgJsonObj.getString("VersionSelectedLastRelease");
-            packages.add(new SelectedPackage(name, packageId, version));
+            packages.add(new SelectedPackage(name, packageId, packageReferenceName, version));
         }
 
         DeploymentProcessTemplate template = new DeploymentProcessTemplate(deploymentId, projectId, packages);

--- a/src/main/java/com/octopusdeploy/api/ReleasesApi.java
+++ b/src/main/java/com/octopusdeploy/api/ReleasesApi.java
@@ -64,7 +64,10 @@ public class ReleasesApi {
             jsonBuilder.append(",SelectedPackages:[");
             Set<String> selectedPackageStrings = new HashSet<String>();
             for (SelectedPackage selectedPackage : selectedPackages) {
-                selectedPackageStrings.add(String.format("{StepName:\"%s\",Version:\"%s\"}", selectedPackage.getStepName(), selectedPackage.getVersion()));
+                // StepName has been deprecated, ActionName should now be used. Continue passing StepName in case an older
+                // version of Octopus server is in use.
+                String actionName = selectedPackage.getStepName();
+                selectedPackageStrings.add(String.format("{StepName:\"%s\",ActionName:\"%s\",PackageReferenceName:\"%s\",Version:\"%s\"}", actionName, actionName, selectedPackage.getPackageReferenceName(), selectedPackage.getVersion()));
             }
             jsonBuilder.append(StringUtils.join(selectedPackageStrings, ","));
             jsonBuilder.append("]");

--- a/src/main/java/com/octopusdeploy/api/data/SelectedPackage.java
+++ b/src/main/java/com/octopusdeploy/api/data/SelectedPackage.java
@@ -13,19 +13,23 @@ public class SelectedPackage {
 
     private final String packageId;
     public String getPackageId() { return packageId; }
-    
+
+    private final String packageReferenceName;
+    public String getPackageReferenceName() { return packageReferenceName; }
+
     private final String version;
     public String getVersion() { return version; }
 
-    public SelectedPackage(String stepName, String packageId, String version) {
+    public SelectedPackage(String stepName, String packageId, String packageReferenceName, String version) {
         this.stepName = stepName;
         this.packageId = packageId;
+        this.packageReferenceName = packageReferenceName;
         this.version = version;
     }
 
     @Override
     public String toString() {
-        return "SelectedPackage [stepName=" + stepName + ", packageId=" + packageId + ", version=" + version + "]";
+        return "SelectedPackage [stepName=" + stepName + ", packageId=" + packageId + ", packageReferenceName=" + packageReferenceName + ", version=" + version + "]";
     }
 
 }

--- a/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/OctopusDeployReleaseRecorder.java
@@ -289,7 +289,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
         } else {
             log.info("Package Configurations:");
             for (PackageConfiguration pc : packageConfigs) {
-                log.info("\t" + pc.getPackageName() + "\tv" + pc.getPackageVersion());
+                log.info("\t" + pc.getPackageName() + "\t" + pc.getPackageReferenceName() + "\tv" + pc.getPackageVersion());
             }
         }
         log.info("=======================");
@@ -312,7 +312,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
         Map<String, SelectedPackage> selectedNames = new HashMap<>();
         if (selectedPackages != null) {
             for (PackageConfiguration pkgConfig : selectedPackages) {
-                SelectedPackage sp = new SelectedPackage(envInjector.injectEnvironmentVariableValues(pkgConfig.getPackageName()), null, envInjector.injectEnvironmentVariableValues(pkgConfig.getPackageVersion()));
+                SelectedPackage sp = new SelectedPackage(envInjector.injectEnvironmentVariableValues(pkgConfig.getPackageName()), null, pkgConfig.getPackageReferenceName(), envInjector.injectEnvironmentVariableValues(pkgConfig.getPackageVersion()));
                 selectedNames.put(envInjector.injectEnvironmentVariableValues(pkgConfig.getPackageName()), sp);
                 combinedList.add(sp);
             }
@@ -331,6 +331,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
             for (SelectedPackage selPkg : defaultPackages.getSteps()) {
                 String stepName = selPkg.getStepName();
                 String packageId = selPkg.getPackageId();
+                String packageReferenceName = selPkg.getPackageReferenceName();
 
                 //Only add if it was not a selected package
                 if (!selectedNames.containsKey(stepName)) {
@@ -342,7 +343,7 @@ public class OctopusDeployReleaseRecorder extends AbstractOctopusDeployRecorder 
                     } else {
                         //Get the default version, if not specified, warn
                         if (defaultPackageVersion != null && !defaultPackageVersion.isEmpty()) {
-                            combinedList.add(new SelectedPackage(stepName, null, defaultPackageVersion));
+                            combinedList.add(new SelectedPackage(stepName, null, packageReferenceName, defaultPackageVersion));
                             log.info(String.format("Using default version (%s) of package %s", defaultPackageVersion, stepName));
                         } else {
                             log.error(String.format("Required package %s not included because package is not in Package Configuration list and no default package version defined", stepName));

--- a/src/main/java/hudson/plugins/octopusdeploy/PackageConfiguration.java
+++ b/src/main/java/hudson/plugins/octopusdeploy/PackageConfiguration.java
@@ -20,7 +20,16 @@ public class PackageConfiguration extends AbstractDescribableImpl<PackageConfigu
     public String getPackageName() {
         return packageName;
     }
-    
+
+    /**
+     * The package reference's name.
+     */
+    private final String packageReferenceName;
+    @Exported
+    public String getPackageReferenceName() {
+        return packageReferenceName;
+    }
+
     /**
      * The version of the package to use.
      */
@@ -31,8 +40,9 @@ public class PackageConfiguration extends AbstractDescribableImpl<PackageConfigu
     }
     
     @DataBoundConstructor
-    public PackageConfiguration(String packageName, String packageVersion) {
+    public PackageConfiguration(String packageName, String packageReferenceName, String packageVersion) {
         this.packageName = packageName.trim();
+        this.packageReferenceName = packageReferenceName.trim();
         this.packageVersion = packageVersion.trim();
     }
     

--- a/src/main/resources/hudson/plugins/octopusdeploy/PackageConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/octopusdeploy/PackageConfiguration/config.jelly
@@ -3,6 +3,9 @@
   <f:entry field="packageName" title="Package">
       <f:textbox />
   </f:entry>
+  <f:entry field="packageReferenceName" title="Package Reference Name">
+      <f:textbox />
+  </f:entry>
   <f:entry field="packageVersion" title="Version">
       <f:textbox />
   </f:entry>

--- a/src/main/resources/hudson/plugins/octopusdeploy/PackageConfiguration/help-packageName.html
+++ b/src/main/resources/hudson/plugins/octopusdeploy/PackageConfiguration/help-packageName.html
@@ -1,5 +1,5 @@
 <div>
-    The package or step-name that requires a version for a nuget package. 
+    The step-name that requires a version for a nuget package.
   <br />
   <em>This field is case-sensitive.</em>
 </div>

--- a/src/main/resources/hudson/plugins/octopusdeploy/PackageConfiguration/help-packageReferenceName.html
+++ b/src/main/resources/hudson/plugins/octopusdeploy/PackageConfiguration/help-packageReferenceName.html
@@ -1,0 +1,5 @@
+<div>
+    The package reference name within the step. This value is required only if you are using the <a href="https://g.octopushq.com/ScriptStepPackageReferences">package referencing feature</a>.
+  <br />
+  <em>This field is case-sensitive.</em>
+</div>


### PR DESCRIPTION
This update is to incorporate the API changes that were made to Octopus server's API in `2018.8`.

The API change requires passing of the logical "reference name" for the package on the step, now that there can be multiple packages per step.

Have tested against an Octopus 2018.9 server, using configurations with and without the package references.

Fixes https://github.com/vistaprint/octopus-jenkins-plugin/issues/24